### PR TITLE
Use new REST client feature to get better simulation result object

### DIFF
--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -1269,7 +1269,7 @@ var simulateCmd = &cobra.Command{
 
 		dataDir := datadir.EnsureSingleDataDir()
 		client := ensureFullClient(dataDir)
-		resp, err := client.TransactionSimulation(data)
+		resp, err := client.SimulateRawTransaction(data)
 		if err != nil {
 			reportErrorf("simulation error: %s", err.Error())
 		}

--- a/daemon/algod/api/client/restClient.go
+++ b/daemon/algod/api/client/restClient.go
@@ -671,6 +671,14 @@ func (client RestClient) SimulateRawTransaction(data []byte) (response model.Sim
 	return
 }
 
+// RawSimulateRawTransaction gets the raw transaction or raw transaction group, and returns relevant simulation results as raw bytes.
+func (client RestClient) RawSimulateRawTransaction(data []byte) (response []byte, err error) {
+	var blob Blob
+	err = client.submitForm(&blob, "/v2/transactions/simulate", rawFormat{Format: "msgpack"}, data, "POST", false /* encodeJSON */, false /* decodeJSON */, false)
+	response = blob
+	return
+}
+
 // StateProofs gets a state proof that covers a given round
 func (client RestClient) StateProofs(round uint64) (response model.StateProofResponse, err error) {
 	err = client.get(&response, fmt.Sprintf("/v2/stateproofs/%d", round), nil)

--- a/daemon/algod/api/server/v2/handlers.go
+++ b/daemon/algod/api/server/v2/handlers.go
@@ -921,28 +921,28 @@ func (v2 *Handlers) RawTransaction(ctx echo.Context) error {
 	return ctx.JSON(http.StatusOK, model.PostTransactionsResponse{TxId: txid.String()})
 }
 
-// preEncodedSimulateTxnResult mirrors model.SimulateTransactionResult
-type preEncodedSimulateTxnResult struct {
+// PreEncodedSimulateTxnResult mirrors model.SimulateTransactionResult
+type PreEncodedSimulateTxnResult struct {
 	Txn                    PreEncodedTxInfo `codec:"txn-result"`
 	MissingSignature       *bool            `codec:"missing-signature,omitempty"`
 	AppBudgetConsumed      *uint64          `codec:"app-budget-consumed,omitempty"`
 	LogicSigBudgetConsumed *uint64          `codec:"logic-sig-budget-consumed,omitempty"`
 }
 
-// preEncodedSimulateTxnGroupResult mirrors model.SimulateTransactionGroupResult
-type preEncodedSimulateTxnGroupResult struct {
-	Txns              []preEncodedSimulateTxnResult `codec:"txn-results"`
+// PreEncodedSimulateTxnGroupResult mirrors model.SimulateTransactionGroupResult
+type PreEncodedSimulateTxnGroupResult struct {
+	Txns              []PreEncodedSimulateTxnResult `codec:"txn-results"`
 	FailureMessage    *string                       `codec:"failure-message,omitempty"`
 	FailedAt          *[]uint64                     `codec:"failed-at,omitempty"`
 	AppBudgetAdded    *uint64                       `codec:"app-budget-added,omitempty"`
 	AppBudgetConsumed *uint64                       `codec:"app-budget-consumed,omitempty"`
 }
 
-// preEncodedSimulateResponse mirrors model.SimulateResponse
-type preEncodedSimulateResponse struct {
+// PreEncodedSimulateResponse mirrors model.SimulateResponse
+type PreEncodedSimulateResponse struct {
 	Version      uint64                             `codec:"version"`
 	LastRound    uint64                             `codec:"last-round"`
-	TxnGroups    []preEncodedSimulateTxnGroupResult `codec:"txn-groups"`
+	TxnGroups    []PreEncodedSimulateTxnGroupResult `codec:"txn-groups"`
 	WouldSucceed bool                               `codec:"would-succeed"`
 }
 

--- a/daemon/algod/api/server/v2/handlers_test.go
+++ b/daemon/algod/api/server/v2/handlers_test.go
@@ -178,7 +178,7 @@ func TestPendingTransactionResponseStruct(t *testing.T) {
 	generatedResponseGraph.AssertEquals(t, customResponseGraph)
 }
 
-// TestSimulateResponseStruct ensures that the hand-written preEncodedSimulateResponse has the same
+// TestSimulateResponseStruct ensures that the hand-written PreEncodedSimulateResponse has the same
 // encoding structure as the generated model.SimulateResponse
 func TestSimulateResponseStruct(t *testing.T) {
 	partitiontest.PartitionTest(t)
@@ -187,7 +187,7 @@ func TestSimulateResponseStruct(t *testing.T) {
 	generatedResponseType := reflect.TypeOf(model.SimulateResponse{})
 	generatedResponseGraph := makeTagGraph(generatedResponseType, make(map[reflect.Type]*tagNode))
 
-	customResponseType := reflect.TypeOf(preEncodedSimulateResponse{})
+	customResponseType := reflect.TypeOf(PreEncodedSimulateResponse{})
 	customResponseGraph := makeTagGraph(customResponseType, make(map[reflect.Type]*tagNode))
 
 	expectedGeneratedTxnGraph := map[string]*tagNode{

--- a/daemon/algod/api/server/v2/utils.go
+++ b/daemon/algod/api/server/v2/utils.go
@@ -353,8 +353,8 @@ func ConvertInnerTxn(txn *transactions.SignedTxnWithAD) PreEncodedTxInfo {
 	return response
 }
 
-func convertTxnResult(txnResult simulation.TxnResult) preEncodedSimulateTxnResult {
-	return preEncodedSimulateTxnResult{
+func convertTxnResult(txnResult simulation.TxnResult) PreEncodedSimulateTxnResult {
+	return PreEncodedSimulateTxnResult{
 		Txn:                    ConvertInnerTxn(&txnResult.Txn),
 		MissingSignature:       trueOrNil(txnResult.MissingSignature),
 		AppBudgetConsumed:      numOrNil(txnResult.AppBudgetConsumed),
@@ -362,13 +362,13 @@ func convertTxnResult(txnResult simulation.TxnResult) preEncodedSimulateTxnResul
 	}
 }
 
-func convertTxnGroupResult(txnGroupResult simulation.TxnGroupResult) preEncodedSimulateTxnGroupResult {
-	txnResults := make([]preEncodedSimulateTxnResult, len(txnGroupResult.Txns))
+func convertTxnGroupResult(txnGroupResult simulation.TxnGroupResult) PreEncodedSimulateTxnGroupResult {
+	txnResults := make([]PreEncodedSimulateTxnResult, len(txnGroupResult.Txns))
 	for i, txnResult := range txnGroupResult.Txns {
 		txnResults[i] = convertTxnResult(txnResult)
 	}
 
-	encoded := preEncodedSimulateTxnGroupResult{
+	encoded := PreEncodedSimulateTxnGroupResult{
 		Txns:              txnResults,
 		FailureMessage:    strOrNil(txnGroupResult.FailureMessage),
 		AppBudgetAdded:    numOrNil(txnGroupResult.AppBudgetAdded),
@@ -384,12 +384,12 @@ func convertTxnGroupResult(txnGroupResult simulation.TxnGroupResult) preEncodedS
 	return encoded
 }
 
-func convertSimulationResult(result simulation.Result) preEncodedSimulateResponse {
-	encodedSimulationResult := preEncodedSimulateResponse{
+func convertSimulationResult(result simulation.Result) PreEncodedSimulateResponse {
+	encodedSimulationResult := PreEncodedSimulateResponse{
 		Version:      result.Version,
 		LastRound:    uint64(result.LastRound),
 		WouldSucceed: result.WouldSucceed,
-		TxnGroups:    make([]preEncodedSimulateTxnGroupResult, len(result.TxnGroups)),
+		TxnGroups:    make([]PreEncodedSimulateTxnGroupResult, len(result.TxnGroups)),
 	}
 
 	for i, txnGroup := range result.TxnGroups {

--- a/libgoal/libgoal.go
+++ b/libgoal/libgoal.go
@@ -1269,14 +1269,28 @@ func (c *Client) Dryrun(data []byte) (resp model.DryrunResponse, err error) {
 	return
 }
 
-// TransactionSimulation takes raw transaction or raw transaction group, and returns relevant simulation results.
-func (c *Client) TransactionSimulation(data []byte) (resp model.SimulateResponse, err error) {
+// SimulateRawTransaction simulates a raw transaction or raw transaction group and returns relevant simulation results.
+func (c *Client) SimulateRawTransaction(data []byte) (result v2.PreEncodedSimulateResponse, err error) {
 	algod, err := c.ensureAlgodClient()
 	if err != nil {
 		return
 	}
-	resp, err = algod.SimulateRawTransaction(data)
+	var resp []byte
+	resp, err = algod.RawSimulateRawTransaction(data)
+	if err != nil {
+		return
+	}
+	err = protocol.DecodeReflect(resp, &result)
 	return
+}
+
+// SimulateRawTransaction simulates a transaction group and returns relevant simulation results.
+func (c *Client) SimulateTransactionGroup(txgroup []transactions.SignedTxn) (result v2.PreEncodedSimulateResponse, err error) {
+	var enc []byte
+	for _, tx := range txgroup {
+		enc = append(enc, protocol.Encode(&tx)...)
+	}
+	return c.SimulateRawTransaction(enc)
 }
 
 // TransactionProof returns a Merkle proof for a transaction in a block.

--- a/libgoal/libgoal.go
+++ b/libgoal/libgoal.go
@@ -1284,7 +1284,7 @@ func (c *Client) SimulateRawTransaction(data []byte) (result v2.PreEncodedSimula
 	return
 }
 
-// SimulateRawTransaction simulates a transaction group and returns relevant simulation results.
+// SimulateTransactionGroup simulates a transaction group and returns relevant simulation results.
 func (c *Client) SimulateTransactionGroup(txgroup []transactions.SignedTxn) (result v2.PreEncodedSimulateResponse, err error) {
 	var enc []byte
 	for _, tx := range txgroup {


### PR DESCRIPTION
## Summary

This PR uses the new REST client feature from https://github.com/algorand/go-algorand/pull/5253 to allow the client to get msgpack simulation responses. With this, the client can decode to the more precise `v2.PreEncodedSimulateResponse` instead of `model.SimulateResponse`.

The only real difference between the two is that `model.SimulateResponse` uses `map[string]interface{}` to represent transactions. This is actually a minor problem, since our JSON decoder will decode large integers as float64, and this could make some responses look strange when `goal clerk simulate` re-encodes the JSON response. For example, this response adds `.0` after integers in the signed transaction:

```json
{
  "last-round": 921,
  "txn-groups": [
    {
      "app-budget-added": 700,
      "app-budget-consumed": 50,
      "failed-at": [
        1
      ],
      "failure-message": "transaction JZ75D2OJEKIUIKLCS2BIRI4JOCMKU5YDP6YADIGZSDZGB7ZZHV4Q: logic eval error: assert failed pc=285. Details: pc=285, opcodes=txnas Accounts\n==\nassert\n",
      "txn-results": [
        {
          "missing-signature": true,
          "txn-result": {
            "pool-error": "",
            "txn": {
              "txn": {
                "amt": 20000000.0,
                "fee": 1000.0,
                "fv": 903.0,
                "gen": "Default Network Template-v1",
                "gh": "9YlKpP21uyjwiWP9dW8qdgyrtXgj+11tFimt2zgzyL0=",
                "grp": "4vqZ9bYDtPUWspTMWjyfFDywcimjOp9vdRvOr+lD6Mw=",
                "lv": 1903.0,
                "note": "LdvdxHRNj64=",
                "rcv": "WCS6TVPJRBSARHLN2326LRU5BYVJZUKI2VJ53CAWKYYHDE455ZGKANWMGM",
                "snd": "KJXS3MA3OEBUAXDU4P6VTHFYEUQUKJYYGD4I2ORDFNZBQI7OOIOYBRH74A",
                "type": "pay"
              }
            }
          }
        },
        {
          "app-budget-consumed": 50,
          "missing-signature": true,
          "txn-result": {
            "pool-error": "",
            "txn": {
              "txn": {
                "apaa": [
                  "J7vOsg==",
                  "AA=="
                ],
                "apid": 1.0,
                "fee": 1000.0,
                "fv": 919.0,
                "gh": "9YlKpP21uyjwiWP9dW8qdgyrtXgj+11tFimt2zgzyL0=",
                "grp": "4vqZ9bYDtPUWspTMWjyfFDywcimjOp9vdRvOr+lD6Mw=",
                "lv": 1919.0,
                "note": "P2NnKKJRzNI=",
                "snd": "ILAZQ3YQUQKGMXTXICRP6422NFVTKLPNQZKHMZH4RSTDO6C7K6HH5VQBRY",
                "type": "appl"
              }
            }
          }
        }
      ]
    }
  ],
  "version": 1,
  "would-succeed": false
}
```

## Test Plan

Note, I'm having issues running the new test in `test/e2e-go/restAPI/restClient_test.go` locally, since algod . I think this may be because it's running an older cached version from my machine
